### PR TITLE
Update current objects page

### DIFF
--- a/documentation/objects/index.md
+++ b/documentation/objects/index.md
@@ -3,9 +3,9 @@ layout: flat
 title: CybOX Object Listing (Archive)
 ---
 
-**IMPORTANT NOTICE:** The CybOX Language has been integrated into [Version 2.0 of Structured Threat Information eXpression (STIX™)](https://oasis-open.github.io/cti-documentation/).
-
 ## CybOX Version 2.1 Objects Archive
+
+**IMPORTANT NOTICE:** The CybOX Language has been integrated into [Version 2.0 of Structured Threat Information eXpression (STIX™)](https://oasis-open.github.io/cti-documentation/).
 
 This page lists the objects currently defined in CybOX, along with some information about each.
 

--- a/documentation/objects/index.md
+++ b/documentation/objects/index.md
@@ -1,10 +1,13 @@
 ---
 layout: flat
-title: CybOX Object Listing
+title: CybOX Object Listing (Archive)
 ---
 
-This page lists the objects currently defined in CybOX, along with some
-information about each.
+**IMPORTANT NOTICE:** The CybOX Language has been integrated into [Version 2.0 of Structured Threat Information eXpression (STIX™)](https://oasis-open.github.io/cti-documentation/).
+
+## CybOX Version 2.1 Objects Archive
+
+This page lists the objects currently defined in CybOX, along with some information about each.
 
 ***
 


### PR DESCRIPTION
Added a notice at top of this page that "Latest Version" referred to throughout the page refers to an archived version of CybOX, and that the CybOX language has been integrated into STIX 2.0.