### PR TITLE
Updated Community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -1,7 +1,9 @@
 ---
 layout: flat
-title: CybOX Community
+title: CybOX Community (Archive)
 ---
+
+**IMPORTANT NOTICE:** The CybOX Language has been [integrated](https://oasis-open.github.io/cti-documentation/stix/compare#one-standard) into [Version 2.0 of Structured Threat Information eXpression (STIX™)](https://oasis-open.github.io/cti-documentation/).
 
 
 ## OASIS Transition


### PR DESCRIPTION
Added a notification at top of page that links to an explanation of CybOX being integrated in STIX on the STIX 2.0 website: https://oasis-open.github.io/cti-documentation/stix/compare#one-standard.