### PR TITLE
Updated main landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,8 +6,10 @@ no_in_page_title: true
 ---
 
 <div class="jumbotron">
-  <h1>Cyber Observable eXpression (CybOX™)</h1>
-  <p>A structured language for cyber observables.</p>
+  <h2>Cyber Observable eXpression (CybOX™) Archive Website</h2>
+  <p>A structured language for cyber observables.</p>  
+    <p></p>
+  <p>**IMPORTANT NOTICE:** The CybOX Language has been <a href="https://oasis-open.github.io/cti-documentation/stix/compare#one-standard">integrated</a> into <a href="https://oasis-open.github.io/cti-documentation/stix/about">Version 2.0 of Structured Threat Information eXpression (STIX™)</a>. Go to the <a href="https://oasis-open.github.io/cti-documentation">STIX 2.0 documentation website</a>.</p>
   <br />
   <div class="row">
     <div class="col-md-6 text-center">


### PR DESCRIPTION
Added a notification at top of page that links to an explanation of CybOX being integrated in STIX that's on the STIX 2.0 website at https://oasis-open.github.io/cti-documentation/stix/compare#one-standard.